### PR TITLE
Fix training footer and update navigation

### DIFF
--- a/app/state-handbook/page.tsx
+++ b/app/state-handbook/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "State Handbook",
+}
+
+export default function StateHandbook() {
+  return (
+    <div className="container mx-auto px-4 py-24 md:py-32">
+      Hello world
+    </div>
+  )
+}

--- a/app/training/how-to-use-electronic-journal/page.tsx
+++ b/app/training/how-to-use-electronic-journal/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Footer from "@/components/footer";
-import Header from "@/components/header";
 
 const essentials = [
   {
@@ -62,7 +60,6 @@ export default function TrainingMaterials() {
 
   return (
     <>
-      <Header />
       <main className="container mx-auto px-4 py-24 md:py-32">
         <div className="max-w-3xl mx-auto mb-16 text-center">
           <h1 className="text-4xl font-bold mb-4">Notary Journal Training</h1>

--- a/app/training/intro-quiz/page.tsx
+++ b/app/training/intro-quiz/page.tsx
@@ -2,8 +2,6 @@
 
 import React from "react"
 import QuizForm from "@/components/QuizForm"
-import Footer from "@/components/footer"
-import Header from "@/components/header"
 
 /**
  * TrainingMaterials

--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -4,8 +4,6 @@ import Link from "next/link"
 
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import Footer from "@/components/footer"
-import Header from "@/components/header"
 
 export const metadata: Metadata = {
   title: "Training Materials - NotaryCentral",
@@ -15,7 +13,6 @@ export const metadata: Metadata = {
 export default function TrainingMaterials() {
   return (
     <>
-      <Header />
       <main className="container mx-auto px-4 py-24 md:py-32">
         <div className="max-w-3xl mx-auto mb-16 text-center">
           <h1 className="text-4xl font-bold mb-4">Training Materials</h1>
@@ -56,7 +53,6 @@ export default function TrainingMaterials() {
           </div>
         </div>
       </main>
-      <Footer />
     </>
   )
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -57,6 +57,16 @@ const menuItems = {
       href: "/post/import-orders",
     },
   ],
+  resources: [
+    {
+      title: "Training",
+      href: "/training",
+    },
+    {
+      title: "State Handbook",
+      href: "/state-handbook",
+    },
+  ],
 }
 
 // US States
@@ -278,13 +288,20 @@ export default function Header() {
                   >
                     ABOUT
                   </Link>
-                  <Link
-                    href="/training"
-                    className="py-2 text-lg font-medium"
-                    onClick={() => setMobileMenuOpen(false)}
-                  >
-                    TRAINING
-                  </Link>
+
+                  <div className="pt-2 border-t border-gray-700/20 dark:border-gray-500/20">
+                    <h4 className="mb-2 text-md font-semibold">RESOURCES</h4>
+                    {menuItems.resources.map((item) => (
+                      <Link
+                        key={item.title}
+                        href={item.href}
+                        className="block py-1 text-base font-medium"
+                        onClick={() => setMobileMenuOpen(false)}
+                      >
+                        {item.title}
+                      </Link>
+                    ))}
+                  </div>
 
                   {/* Show SOLUTIONS and FEATURES inline on mobile */}
                   <div className="pt-2 border-t border-gray-700/20 dark:border-gray-500/20">
@@ -384,9 +401,32 @@ export default function Header() {
               <Link href="/post/why-did-i-start-notarycentral" className="text-sm font-medium hover:text-primary">
                 ABOUT
               </Link>
-              <Link href="/training" className="text-sm font-medium hover:text-primary">
-                TRAINING
-              </Link>
+
+              <NavigationMenu>
+                <NavigationMenuList>
+                  <NavigationMenuItem>
+                    <NavigationMenuTrigger className="text-sm font-medium bg-transparent hover:bg-transparent hover:text-primary">
+                      RESOURCES
+                    </NavigationMenuTrigger>
+                    <NavigationMenuContent>
+                      <ul className="p-4 space-y-2">
+                        {menuItems.resources.map((item) => (
+                          <li key={item.title}>
+                            <NavigationMenuLink asChild>
+                              <Link
+                                href={item.href}
+                                className="block select-none rounded-md p-2 text-sm no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground"
+                              >
+                                {item.title}
+                              </Link>
+                            </NavigationMenuLink>
+                          </li>
+                        ))}
+                      </ul>
+                    </NavigationMenuContent>
+                  </NavigationMenuItem>
+                </NavigationMenuList>
+              </NavigationMenu>
 
               {/* Solutions & Features in a NavigationMenu for desktop */}
               <NavigationMenu>


### PR DESCRIPTION
## Summary
- drop header/footer duplicates from training pages
- add new `state-handbook` route
- update navigation to replace **Training** with a **Resources** menu

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6854b71d342083238b8f95a860c3293a