### PR TITLE
Rename state handbook links

### DIFF
--- a/app/official-notary-rules/[state]/page.tsx
+++ b/app/official-notary-rules/[state]/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next"
+import manuals, { NotaryManual } from "@/lib/notaryManuals"
+
+export const metadata: Metadata = {
+  title: "Official notary rules by state",
+}
+
+interface Props {
+  params: { state: string }
+}
+
+export default function OfficialNotaryRulesByState({ params }: Props) {
+  const name = params.state.replace(/-/g, " ")
+  const words = name
+    .split(" ")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+  const stateName = words.join(" ")
+
+  const manual: NotaryManual | undefined = (manuals as any)[params.state]
+
+  return (
+    <div className="container mx-auto px-4 py-24 md:py-32">
+      <h1 className="text-center text-3xl md:text-4xl font-extrabold mb-6">
+        Official rules for {stateName}
+      </h1>
+      {manual ? (
+        <p className="text-center">
+          <a
+            href={manual.url}
+            className="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {manual.title}
+          </a>
+        </p>
+      ) : (
+        <p className="text-center">Manual not available.</p>
+      )}
+    </div>
+  )
+}

--- a/app/official-notary-rules/page.tsx
+++ b/app/official-notary-rules/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 
 export const metadata: Metadata = {
   title: "Official notary rules",
@@ -19,7 +20,14 @@ export default function StateHandbook() {
           <h2 className="font-semibold mb-2">A–I</h2>
           <ul className="space-y-1">
             {["Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado", "Connecticut", "Delaware", "District of Columbia", "Florida", "Georgia", "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa"].map(state => (
-              <li key={state} className="hover:underline cursor-pointer">{state}</li>
+              <li key={state}>
+                <Link
+                  href={`/official-notary-rules/${state.toLowerCase().replace(/\s+/g, "-")}`}
+                  className="hover:underline"
+                >
+                  {state}
+                </Link>
+              </li>
             ))}
           </ul>
         </div>
@@ -28,7 +36,14 @@ export default function StateHandbook() {
           <h2 className="font-semibold mb-2">K–N</h2>
           <ul className="space-y-1">
             {["Kansas", "Kentucky", "Louisiana", "Maine", "Maryland", "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York", "North Carolina", "North Dakota"].map(state => (
-              <li key={state} className="hover:underline cursor-pointer">{state}</li>
+              <li key={state}>
+                <Link
+                  href={`/official-notary-rules/${state.toLowerCase().replace(/\s+/g, "-")}`}
+                  className="hover:underline"
+                >
+                  {state}
+                </Link>
+              </li>
             ))}
           </ul>
         </div>
@@ -37,7 +52,14 @@ export default function StateHandbook() {
           <h2 className="font-semibold mb-2">O–W</h2>
           <ul className="space-y-1">
             {["Ohio", "Oklahoma", "Oregon", "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas", "Utah", "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming"].map(state => (
-              <li key={state} className="hover:underline cursor-pointer">{state}</li>
+              <li key={state}>
+                <Link
+                  href={`/official-notary-rules/${state.toLowerCase().replace(/\s+/g, "-")}`}
+                  className="hover:underline"
+                >
+                  {state}
+                </Link>
+              </li>
             ))}
           </ul>
         </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -63,8 +63,8 @@ const menuItems = {
       href: "/training",
     },
     {
-      title: "State Handbook",
-      href: "/state-handbook",
+      title: "Official notary rules",
+      href: "/official-notary-rules",
     },
   ],
 }

--- a/data/notary-manuals.json
+++ b/data/notary-manuals.json
@@ -1,0 +1,10 @@
+{
+  "new-jersey": {
+    "title": "New Jersey Notary Public Manual",
+    "url": "https://www.nj.gov/treasury/revenue/pdf/NotaryPublicManual.pdf"
+  },
+  "texas": {
+    "title": "Texas Notary Public Handbook",
+    "url": "https://www.sos.state.tx.us/statdoc/bkbnotarypublic.pdf"
+  }
+}

--- a/lib/notaryManuals.ts
+++ b/lib/notaryManuals.ts
@@ -1,0 +1,10 @@
+import manuals from '@/data/notary-manuals.json'
+
+export interface NotaryManual {
+  title: string
+  url: string
+}
+
+export type NotaryManuals = Record<string, NotaryManual>
+
+export default manuals as NotaryManuals


### PR DESCRIPTION
## Summary
- rename nav link to Official notary rules
- move `state-handbook` route to `official-notary-rules`
- add dynamic state page under `official-notary-rules/[state]`
- list each state as a link to its page
- load PDF links from new `notary-manuals.json`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c1ed6d688323a773261468393908