### PR TITLE
Move state compliance notice to footer

### DIFF
--- a/app/how-to-become-a-notary/[state]/page.tsx
+++ b/app/how-to-become-a-notary/[state]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 import { getStateData } from '@/lib/howToBecome'
-import StateCompliance from '@/components/StateCompliance'
 
 export const metadata: Metadata = {
   title: 'How to become a notary',
@@ -65,7 +64,6 @@ export default function HowToBecomeState({ params }: Props) {
         <p className="text-center">Information not available.</p>
       )}
     </div>
-    <StateCompliance stateName={stateName} />
     </>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@ import Hero from "@/components/hero"
 import Features from "@/components/features"
 import Testimonials from "@/components/testimonials"
 import Pricing from "@/components/pricing"
-import StateCompliance from "@/components/StateCompliance"
 import FAQ from "@/components/faq"
 import CTA from "@/components/cta"
 
@@ -13,7 +12,6 @@ export default function Home() {
       <Features />
       <Testimonials />
       <Pricing />
-      <StateCompliance />
       <FAQ />
       <CTA />
     </>

--- a/components/StateCompliance.tsx
+++ b/components/StateCompliance.tsx
@@ -41,8 +41,8 @@ export default function StateCompliance({ stateName }: Props) {
   const answerClass = compliant ? "text-green-600" : "text-red-600"
 
   return (
-    <section className="py-12 md:py-20 bg-secondary dark:bg-gray-900 border-t">
-      <div className="container mx-auto px-4 text-center space-y-4">
+    <section className="py-6 bg-secondary dark:bg-gray-900 border-t">
+      <div className="container mx-auto px-4 text-center space-y-3">
         <h2 className="text-2xl md:text-3xl font-bold">
           Is NotaryCentral compliant in {displayName}?
         </h2>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { Facebook, Instagram, Youtube, Apple, SmartphoneIcon as Android, Rss, Linkedin } from "lucide-react"
+import StateCompliance from "@/components/StateCompliance"
 import { useEffect, useState } from "react"
 
 const footerLinks = [
@@ -62,6 +63,7 @@ export default function Footer() {
 
   return (
     <footer className="bg-gray-100 dark:bg-gray-900 pt-16 pb-8">
+      <StateCompliance />
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-8 mb-12">
           <div className="lg:col-span-2">


### PR DESCRIPTION
## Summary
- prune `StateCompliance` from Home and state pages
- slim down the component styling
- reuse it at the start of the footer

## Testing
- `npm run lint` *(fails: unescaped entity errors)*
- `npm run build` *(fails: fetch failed while prerendering /blog)*

------
https://chatgpt.com/codex/tasks/task_e_6884d0aeac1c832391dad9e5b2ad15c7