### PR TITLE
Add compliance preview component

### DIFF
--- a/app/how-to-become-a-notary/[state]/page.tsx
+++ b/app/how-to-become-a-notary/[state]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getStateData } from '@/lib/howToBecome'
+import CompliancePreview from '@/components/CompliancePreview'
 
 export const metadata: Metadata = {
   title: 'How to become a notary',
@@ -64,6 +65,7 @@ export default function HowToBecomeState({ params }: Props) {
         <p className="text-center">Information not available.</p>
       )}
     </div>
+    <CompliancePreview />
     </>
   )
 }

--- a/components/CompliancePreview.tsx
+++ b/components/CompliancePreview.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import Link from "next/link"
+
+export default function CompliancePreview() {
+  return (
+    <section className="py-6 border-t border-b border-gray-200 dark:border-gray-800 bg-secondary dark:bg-gray-900 mb-4">
+      <div className="container mx-auto px-4 text-center space-y-4">
+        <div className="relative w-full max-w-2xl mx-auto aspect-video">
+          <iframe
+            src="https://www.youtube.com/embed/T-XIpwwQXzE"
+            title="Compliance with NotaryCentral"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className="absolute inset-0 w-full h-full rounded-lg shadow-lg"
+          />
+        </div>
+        <p className="text-lg">NotaryCentral helps you stay compliant with state laws.</p>
+        <p>
+          <Link href="/compliance" className="underline">
+            Learn more
+          </Link>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -4,13 +4,16 @@ import Link from "next/link"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { Facebook, Instagram, Youtube, Apple, SmartphoneIcon as Android, Rss, Linkedin } from "lucide-react"
-import StateCompliance from "@/components/StateCompliance"
+import CompliancePreview from "@/components/CompliancePreview"
 import { useEffect, useState } from "react"
 
 const footerLinks = [
   {
     title: "Product",
-    links: [{ name: "Pricing", href: "/pricing" }],
+    links: [
+      { name: "Pricing", href: "/pricing" },
+      { name: "Compliance", href: "/compliance" },
+    ],
   },
   {
     title: "Resources",
@@ -63,7 +66,7 @@ export default function Footer() {
 
   return (
     <footer className="bg-gray-100 dark:bg-gray-900 pt-16 pb-8">
-      <StateCompliance />
+      <CompliancePreview />
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-8 mb-12">
           <div className="lg:col-span-2">


### PR DESCRIPTION
## Summary
- create `CompliancePreview` component with video and link
- show `CompliancePreview` in footer instead of `StateCompliance`
- add Compliance link in footer
- show `CompliancePreview` on state pages

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*
- `npm run build` *(fails: prerendering page error)*

------
https://chatgpt.com/codex/tasks/task_e_688691adaa44832388b6714685fee006