### PR TITLE
Hide site header and footer in print

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -92,3 +92,10 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+@media print {
+  header,
+  footer {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Hide header and footer elements when printing so that PDFs from macOS omit site chrome.

## Testing
- `npm test` *(fails: Missing script "test")*
- `pnpm run lint` *(fails: react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fa5484d048323a0d84eafe68c2fc8