### PR TITLE
Refactor navigation to use use cases and add placeholder pages

### DIFF
--- a/app/general-notary-work/page.tsx
+++ b/app/general-notary-work/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "General Notary Work",
+  description: "Tools for everyday notarization tasks.",
+}
+
+export default function GeneralNotaryWorkPage() {
+  return (
+    <div className="container mx-auto px-4 py-24 md:py-32">
+      <h1 className="text-3xl font-bold mb-4">General Notary Work</h1>
+      <p>Content coming soon.</p>
+    </div>
+  )
+}

--- a/app/general-notary-work/page.tsx
+++ b/app/general-notary-work/page.tsx
@@ -1,15 +1,45 @@
+import fs from "fs"
+import path from "path"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
   title: "General Notary Work",
-  description: "Tools for everyday notarization tasks.",
+  description:
+    "Automate routine notarizations with unified scheduling, mileage tracking, and business metrics.",
 }
 
 export default function GeneralNotaryWorkPage() {
+  const markdownPath = path.join(
+    process.cwd(),
+    "data/blog",
+    "general-notary-work.md"
+  )
+  const markdown = fs.readFileSync(markdownPath, "utf8")
+  const lastUpdatedMatch = markdown.match(
+    /Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/
+  )
+  const isoDate = lastUpdatedMatch
+    ? new Date(lastUpdatedMatch[1]).toISOString()
+    : undefined
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: metadata.title,
+    description: metadata.description,
+    author: { "@type": "Person", name: "Alexander Leon" },
+    datePublished: isoDate,
+    dateModified: isoDate,
+  }
+
   return (
-    <div className="container mx-auto px-4 py-24 md:py-32">
-      <h1 className="text-3xl font-bold mb-4">General Notary Work</h1>
-      <p>Content coming soon.</p>
+    <div className="prose lg:prose-lg dark:prose-invert mx-auto px-4 py-24 md:py-32 max-w-4xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
     </div>
   )
 }

--- a/app/loan-signings/page.tsx
+++ b/app/loan-signings/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Loan Signings",
+  description: "Learn how NotaryCentral supports loan signing appointments.",
+}
+
+export default function LoanSigningsPage() {
+  return (
+    <div className="container mx-auto px-4 py-24 md:py-32">
+      <h1 className="text-3xl font-bold mb-4">Loan Signings</h1>
+      <p>Content coming soon.</p>
+    </div>
+  )
+}

--- a/app/loan-signings/page.tsx
+++ b/app/loan-signings/page.tsx
@@ -1,15 +1,41 @@
+import fs from "fs"
+import path from "path"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
   title: "Loan Signings",
-  description: "Learn how NotaryCentral supports loan signing appointments.",
+  description:
+    "Automate loan signing management from email intake to digital journaling and scheduling.",
 }
 
 export default function LoanSigningsPage() {
+  const markdownPath = path.join(process.cwd(), "data/blog", "loan-signings.md")
+  const markdown = fs.readFileSync(markdownPath, "utf8")
+  const lastUpdatedMatch = markdown.match(
+    /Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/
+  )
+  const isoDate = lastUpdatedMatch
+    ? new Date(lastUpdatedMatch[1]).toISOString()
+    : undefined
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: metadata.title,
+    description: metadata.description,
+    author: { "@type": "Person", name: "Alexander Leon" },
+    datePublished: isoDate,
+    dateModified: isoDate,
+  }
+
   return (
-    <div className="container mx-auto px-4 py-24 md:py-32">
-      <h1 className="text-3xl font-bold mb-4">Loan Signings</h1>
-      <p>Content coming soon.</p>
+    <div className="prose lg:prose-lg dark:prose-invert mx-auto px-4 py-24 md:py-32 max-w-4xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
     </div>
   )
 }

--- a/app/other-appointments/page.tsx
+++ b/app/other-appointments/page.tsx
@@ -1,15 +1,45 @@
+import fs from "fs"
+import path from "path"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "Other appointments",
-  description: "Manage miscellaneous appointments beyond standard notarizations.",
+  title: "Other Appointment Types",
+  description:
+    "Handle apostilles, fingerprinting, and custom services with unified intake and billing.",
 }
 
 export default function OtherAppointmentsPage() {
+  const markdownPath = path.join(
+    process.cwd(),
+    "data/blog",
+    "other-appointments.md"
+  )
+  const markdown = fs.readFileSync(markdownPath, "utf8")
+  const lastUpdatedMatch = markdown.match(
+    /Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/
+  )
+  const isoDate = lastUpdatedMatch
+    ? new Date(lastUpdatedMatch[1]).toISOString()
+    : undefined
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: metadata.title,
+    description: metadata.description,
+    author: { "@type": "Person", name: "Alexander Leon" },
+    datePublished: isoDate,
+    dateModified: isoDate,
+  }
+
   return (
-    <div className="container mx-auto px-4 py-24 md:py-32">
-      <h1 className="text-3xl font-bold mb-4">Other appointments</h1>
-      <p>Content coming soon.</p>
+    <div className="prose lg:prose-lg dark:prose-invert mx-auto px-4 py-24 md:py-32 max-w-4xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
     </div>
   )
 }

--- a/app/other-appointments/page.tsx
+++ b/app/other-appointments/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Other appointments",
+  description: "Manage miscellaneous appointments beyond standard notarizations.",
+}
+
+export default function OtherAppointmentsPage() {
+  return (
+    <div className="container mx-auto px-4 py-24 md:py-32">
+      <h1 className="text-3xl font-bold mb-4">Other appointments</h1>
+      <p>Content coming soon.</p>
+    </div>
+  )
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -18,7 +18,39 @@ import { Menu, X } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 
 const menuItems = {
-  solutions: [
+  useCases: [
+    {
+      title: "E-Journal",
+      description: "Digitally record and store all your notary transactions",
+      href: "/post/e-journal",
+    },
+    {
+      title: "Loan Signings",
+      description: "Streamline loan document notarizations",
+      href: "/loan-signings",
+    },
+    {
+      title: "General Notary Work",
+      description: "Manage everyday notarizations efficiently",
+      href: "/general-notary-work",
+    },
+    {
+      title: "Other appointments",
+      description: "Track miscellaneous appointments",
+      href: "/other-appointments",
+    },
+  ],
+  features: [
+    {
+      title: "Expense tracking",
+      description: "Track and categorize all your business expenses",
+      href: "/post/expense-tracking",
+    },
+    {
+      title: "Import Orders",
+      description: "Easily import signing orders from other platforms",
+      href: "/import-orders",
+    },
     {
       title: "Accounting",
       description: "Track income, expenses, and generate tax reports automatically to maximize deductions.",
@@ -35,26 +67,9 @@ const menuItems = {
       href: "/business-health-insights",
     },
     {
-      title: "e-Journal",
-      description: "Digitally record and store all your notary transactions",
-      href: "/post/e-journal",
-    },
-    {
       title: "Scheduling",
       description: "Create a shareable calendar link where new appointments automatically sync with your existing calendar events.",
       href: "/post/online-scheduler",
-    },
-  ],
-  features: [
-    {
-      title: "Expense tracking",
-      description: "Track and categorize all your business expenses",
-      href: "/post/expense-tracking",
-    },
-    {
-      title: "Import Orders",
-      description: "Easily import signing orders from other platforms",
-      href: "/import-orders",
     },
   ],
   resources: [
@@ -311,10 +326,10 @@ export default function Header() {
                     ))}
                   </div>
 
-                  {/* Show SOLUTIONS and FEATURES inline on mobile */}
+                  {/* Show USE CASES and FEATURES inline on mobile */}
                   <div className="pt-2 border-t border-gray-700/20 dark:border-gray-500/20">
-                    <h4 className="mb-2 text-md font-semibold">SOLUTIONS</h4>
-                    {menuItems.solutions.map((item) => (
+                    <h4 className="mb-2 text-md font-semibold">USE CASES</h4>
+                    {menuItems.useCases.map((item) => (
                       <Link
                         key={item.title}
                         href={item.href}
@@ -436,21 +451,21 @@ export default function Header() {
                 </NavigationMenuList>
               </NavigationMenu>
 
-              {/* Solutions & Features in a NavigationMenu for desktop */}
+              {/* Use Cases & Features in a NavigationMenu for desktop */}
               <NavigationMenu>
                 <NavigationMenuList>
                   <NavigationMenuItem>
                     <NavigationMenuTrigger className="text-sm font-medium bg-transparent hover:bg-transparent hover:text-primary">
-                      SOLUTIONS & FEATURES
+                      USE CASES & FEATURES
                     </NavigationMenuTrigger>
                     <NavigationMenuContent>
                       <div className="grid gap-6 p-6 md:w-[600px] lg:w-[700px]" style={{ transform: "translateX(0)" }}>
                         <div className="grid gap-3">
                           <h3 className="text-lg font-medium text-gray-500 dark:text-gray-400">
-                            SOLUTIONS
+                            USE CASES
                           </h3>
                           <ul className="grid gap-3 md:grid-cols-2">
-                            {menuItems.solutions.map((item) => (
+                            {menuItems.useCases.map((item) => (
                               <li key={item.title}>
                                 <NavigationMenuLink asChild>
                                   <Link

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -35,7 +35,7 @@ const menuItems = {
       href: "/general-notary-work",
     },
     {
-      title: "Other appointments",
+      title: "Other Appointment Types",
       description: "Track miscellaneous appointments",
       href: "/other-appointments",
     },

--- a/data/blog/general-notary-work.md
+++ b/data/blog/general-notary-work.md
@@ -1,0 +1,7 @@
+# General Notary Work
+
+Last updated April 18, 2025
+
+General notarizations benefit from the same automated intake: forwarding a request routes the appointment into the unified calendar without manual entry. The platform’s scheduling page keeps all appointment details in one place and prevents double-booking through real-time availability and cross-device syncing.
+
+Mileage and expense tracking feeds directly into accounting so routine jobs generate accurate cost and deduction records. Income, travel costs, outstanding invoices, and other metrics appear on a dashboard, letting notaries gauge the impact of day-to-day work at a glance.

--- a/data/blog/loan-signings.md
+++ b/data/blog/loan-signings.md
@@ -1,0 +1,7 @@
+# Loan Signings
+
+Last updated April 18, 2025
+
+NotaryCentral automates loan-signing management by allowing email-based forwarding of signing requests; each one is parsed and dropped into the correct calendar slot for easy tracking. Every loan signing is logged in a state-aware digital journal with built‑in receipts and tamper‑evident records, keeping compliance and documentation in one place.
+
+A business‑health dashboard surfaces signing volume and revenue trends, helping notaries monitor performance over time. Dedicated scheduling tools provide service-based pricing, calendar sync, reminders, and optional Square pre‑payment so loan signings stay organized from booking to completion.

--- a/data/blog/other-appointments.md
+++ b/data/blog/other-appointments.md
@@ -1,0 +1,7 @@
+# Other Appointment Types
+
+Last updated April 18, 2025
+
+Appointment imports are not limited to loans or basic notarizations—apostille requests, fingerprinting sessions, and any custom service type are automatically classified and placed on the calendar for tracking. The public scheduling page supports these varied services with configurable pricing and optional up‑front payments via Square, streamlining confirmation and reducing no‑shows for any appointment type.
+
+Because journal entries, scheduling, and billing share the same workspace, notaries can track uncommon or niche appointments with the same clarity they use for core services.


### PR DESCRIPTION
## Summary
- rename navigation section to **Use Cases** and move former solutions under features
- add placeholder pages for Loan Signings, General Notary Work, and Other appointments

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6896b7ad5a5c8323929352e267e72948