### PR TITLE
Add journal comparison page and footer link

### DIFF
--- a/app/journal-comparison/page.tsx
+++ b/app/journal-comparison/page.tsx
@@ -1,0 +1,46 @@
+import fs from "fs"
+import path from "path"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Notary Journal Comparison",
+  description:
+    "Compare NotaryCentral's Electronic Journal with Jurat Inc.'s e-journal and traditional paper journals.",
+}
+
+export default function JournalComparisonPage() {
+  const markdownPath = path.join(
+    process.cwd(),
+    "data/blog",
+    "journal-comparison.md"
+  )
+  const markdown = fs.readFileSync(markdownPath, "utf8")
+  const lastUpdatedMatch = markdown.match(
+    /Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/
+  )
+  const isoDate = lastUpdatedMatch
+    ? new Date(lastUpdatedMatch[1]).toISOString()
+    : undefined
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: metadata.title,
+    description: metadata.description,
+    author: { "@type": "Person", name: "Alexander Leon" },
+    datePublished: isoDate,
+    dateModified: isoDate,
+  }
+
+  return (
+    <div className="prose lg:prose-lg dark:prose-invert mx-auto px-4 py-24 md:py-32 max-w-4xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+    </div>
+  )
+}
+

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -22,6 +22,7 @@ const footerLinks = [
       { name: "Support", href: "/support" },
       { name: "Comparison with NotaryGadget", href: "/notary-app-comparison" },
       { name: "Notary Business Software Ultimate Guide", href: "/notary-business-software-ultimate-guide" },
+      { name: "Journal Comparison", href: "/journal-comparison" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- create `/journal-comparison` page that renders `journal-comparison.md` with GFM support
- link Journal Comparison under **Resources** in the footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed; attempted installation conflicted with peer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6897fbabcebc8323a0b0b0e3d637f014