### PR TITLE
Expand meta descriptions for better SEO

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -9,7 +9,8 @@ import { ChevronRight } from "lucide-react"
 
 export const metadata = {
   title: "Blog | NotaryCentral",
-  description: "Latest news, tips, and updates for notaries",
+  description:
+    "Explore the NotaryCentral blog for practical tips, industry news, compliance updates, and guides that help notaries run secure, profitable practices with ease.",
 }
 
 export default async function BlogPage() {

--- a/app/compliance/page.tsx
+++ b/app/compliance/page.tsx
@@ -3,7 +3,8 @@ import StateCompliance from "@/components/StateCompliance"
 
 export const metadata: Metadata = {
   title: "Compliance | NotaryCentral",
-  description: "Learn how NotaryCentral helps you stay compliant with state laws.",
+  description:
+    "See how NotaryCentral keeps you compliant with laws through recordkeeping, ID capture, and reminders, giving notaries secure workflows that stand up to audits.",
 }
 
 export default function CompliancePage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,8 @@ const ebGaramond = EB_Garamond({
 
 export const metadata: Metadata = {
   title: "NotaryCentral - The Super App for Notaries",
-  description: "The all-in-one app to keep you compliant and organized",
+  description:
+    "NotaryCentral gives notaries digital journals, scheduling, compliance tips, and training so every signing stays organized, secure, and aligned with state law.",
   generator: 'v0.dev'
 }
 

--- a/app/legal/terms-of-use/page.tsx
+++ b/app/legal/terms-of-use/page.tsx
@@ -3,7 +3,8 @@ import TermsOfUseClient from "./TermsOfUseClient"
 
 export const metadata: Metadata = {
   title: "Terms of Service",
-  description: "These terms were updated and effective as of July 31st, 2024",
+  description:
+    "Review NotaryCentral's Terms of Service covering user responsibilities, privacy practices, and liability limits so you know the rules for accessing our tools.",
 }
 
 export default function TermsOfService() {

--- a/app/official-notary-rules/page.tsx
+++ b/app/official-notary-rules/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link"
 
 export const metadata: Metadata = {
   title: "Official notary rules",
+  description:
+    "Browse notary rules for every state with links to journal requirements and legal guidance, helping you understand regulations that govern your commission.",
 }
 
 export default function StateHandbook() {

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -37,13 +37,20 @@ export async function generateMetadata({ params }: { params: { slug: string } })
         .map((child: any) => child.text)
         .join("")
         .trim()
-        .slice(0, 155)
     }
   }
 
+  const baseDescription =
+    "Explore this NotaryCentral article for guidance, tips, and compliance insights that help notaries stay organized, secure, and ready for every appointment."
+
+  const description =
+    fallbackDescription && fallbackDescription.length >= 150
+      ? fallbackDescription.slice(0, 160)
+      : baseDescription
+
   return {
     title: `${post.title} | NotaryCentral Blog`,
-    description: fallbackDescription || "Read this article on the NotaryCentral blog",
+    description,
   }
 }
 

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,8 +1,11 @@
-"use client"
-
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardFooter } from "@/components/ui/card"
+import type { Metadata } from "next"
 import PricingView from "@/components/pricing"
+
+export const metadata: Metadata = {
+  title: "Pricing | NotaryCentral",
+  description:
+    "See how NotaryCentral pricing fits your budget with plans that include journals, scheduling, and compliance tools that scale as your notary business grows.",
+}
 
 export default function Pricing() {
 

--- a/app/training/how-to-use-electronic-journal/head.tsx
+++ b/app/training/how-to-use-electronic-journal/head.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+
+export default function Head() {
+  return (
+    <>
+      <title>Notary Journal Training Path | NotaryCentral</title>
+      <meta
+        name="description"
+        content="Use this NotaryCentral training path to learn the electronic journal, from basic entries to offline mode and thumbprints, linking to articles and quizzes."
+      />
+    </>
+  )
+}

--- a/app/training/intro-quiz/head.tsx
+++ b/app/training/intro-quiz/head.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+
+export default function Head() {
+  return (
+    <>
+      <title>Notary Journal Basics Quiz | NotaryCentral</title>
+      <meta
+        name="description"
+        content="Test your understanding of notary journal basics with this NotaryCentral quiz before creating your first electronic entry and progressing to advanced features."
+      />
+    </>
+  )
+}

--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button"
 
 export const metadata: Metadata = {
   title: "Training Materials - NotaryCentral",
-  description: "Explore available training materials to help you get started with NotaryCentral features.",
+  description:
+    "NotaryCentral training guides you through journals, scheduling, and key tools with tutorials so notaries of any experience work efficiently and stay compliant.",
 }
 
 export default function TrainingMaterials() {


### PR DESCRIPTION
## Summary
- Lengthen global meta description to highlight NotaryCentral's digital journals, scheduling, compliance and training features
- Add 150+ character descriptions to blog, pricing, compliance, training, official rules and terms pages for richer search snippets
- Ensure blog posts fallback to a detailed default description and supply head metadata for training path and quiz pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from... and many react/no-unescaped-entities errors)*
- `npm run build` *(fails: fetch failed during prerendering /blog)*

------
https://chatgpt.com/codex/tasks/task_e_689e4c3925bc8323bd9e0a906e43ecc7