### PR TITLE
Expand meta descriptions for better SEO

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "About",
   description:
-    "The future of notarial work is hybrid, mobile, and highly regulated—and that combination demands better tools."
+    "Learn why the future of notarial work is hybrid, mobile, and tightly regulated, and how NotaryCentral delivers secure tools and training so notaries can thrive."
 }
 
 export default function WhyNotaryCentralFaqPage() {

--- a/app/accounting/page.tsx
+++ b/app/accounting/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Accounting",
   description:
-    "Easily generate and export year-end tax reports. Stay compliant and get the best tax breaks for notaries."
+    "Manage notary finances with auto-categorized expenses, mileage logs, and reports that simplify tax prep, support audits, and keep books accurate year-round."
 }
 
 export default function WhyNotaryCentralFaqPage() {

--- a/app/ask-ai/page.tsx
+++ b/app/ask-ai/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Ask AI",
   description:
-    "Get instant answers to state-specific notary law questions"
+    "Ask AI gives instant, state-specific answers to notary law questions using handbooks so you can work confidently without wading through dense legal text."
 }
 
 export default function WhyNotaryCentralFaqPage() {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -9,7 +9,8 @@ import { ChevronRight } from "lucide-react"
 
 export const metadata = {
   title: "Blog | NotaryCentral",
-  description: "Latest news, tips, and updates for notaries",
+  description:
+    "Explore the NotaryCentral blog for practical tips, industry news, compliance updates, and guides that help notaries run secure, profitable practices with ease.",
 }
 
 export default async function BlogPage() {

--- a/app/business-health-insights/page.tsx
+++ b/app/business-health-insights/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Business Health Insights",
   description:
-    "Running a notary business means juggling appointments, mileage, and stacks of receipts. NotaryCentral's Business Health dashboard turns that chaos into clear insights so you always know where you stand."
+    "Track appointments, mileage, revenue, and expenses in NotaryCentral's Business Health dashboard so you always know how your notary business is performing."
 }
 
 export default function WhyNotaryCentralFaqPage() {

--- a/app/compliance/page.tsx
+++ b/app/compliance/page.tsx
@@ -3,7 +3,8 @@ import StateCompliance from "@/components/StateCompliance"
 
 export const metadata: Metadata = {
   title: "Compliance | NotaryCentral",
-  description: "Learn how NotaryCentral helps you stay compliant with state laws.",
+  description:
+    "See how NotaryCentral keeps you compliant with laws through recordkeeping, ID capture, and reminders, giving notaries secure workflows that stand up to audits.",
 }
 
 export default function CompliancePage() {

--- a/app/general-notary-work/page.tsx
+++ b/app/general-notary-work/page.tsx
@@ -7,7 +7,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "General Notary Work",
   description:
-    "Automate routine notarizations with unified scheduling, mileage tracking, and business metrics.",
+    "Automate routine notarizations with scheduling, mileage tracking, and business metrics in one workspace so general notary work stays efficient and compliant.",
 }
 
 export default function GeneralNotaryWorkPage() {

--- a/app/how-to-become-a-notary/[state]/page.tsx
+++ b/app/how-to-become-a-notary/[state]/page.tsx
@@ -4,6 +4,8 @@ import CompliancePreview from '@/components/CompliancePreview'
 
 export const metadata: Metadata = {
   title: 'How to become a notary',
+  description:
+    'Learn the steps, eligibility, forms, and resources for becoming a notary in your state so you can start serving clients confidently and stay compliant.',
 }
 
 interface Props {

--- a/app/how-to-become-a-notary/page.tsx
+++ b/app/how-to-become-a-notary/page.tsx
@@ -4,6 +4,8 @@ import { getAvailableStates } from '@/lib/howToBecome'
 
 export const metadata: Metadata = {
   title: 'How to become a notary',
+  description:
+    'Select your state to learn the requirements for becoming a notary, including application details, training, and resources to get commissioned quickly.',
 }
 
 function formatStateName(slug: string) {

--- a/app/import-orders/page.tsx
+++ b/app/import-orders/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Import orders",
   description:
-    "NotaryCentral eliminates that busywork by letting you forward an order email directly into your workspace."
+    "Forward order emails into NotaryCentral to create appointments, attach documents, and populate client details, saving time and reducing manual data entry."
 }
 
 export default function WhyNotaryCentralFaqPage() {

--- a/app/journal-comparison/page.tsx
+++ b/app/journal-comparison/page.tsx
@@ -7,7 +7,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Notary Journal Comparison",
   description:
-    "Compare NotaryCentral's Electronic Journal with Jurat Inc.'s e-journal and traditional paper journals.",
+    "Compare NotaryCentral's electronic journal with Jurat Inc.'s e-journal and paper logs to see which option keeps records accurate, secure, and ready for audits.",
 }
 
 export default function JournalComparisonPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,8 @@ const ebGaramond = EB_Garamond({
 
 export const metadata: Metadata = {
   title: "NotaryCentral - The Super App for Notaries",
-  description: "The all-in-one app to keep you compliant and organized",
+  description:
+    "NotaryCentral gives notaries digital journals, scheduling, compliance tips, and training so every signing stays organized, secure, and aligned with state law.",
   generator: 'v0.dev'
 }
 

--- a/app/legal/extract-id-privacy-policy/page.tsx
+++ b/app/legal/extract-id-privacy-policy/page.tsx
@@ -3,7 +3,7 @@ import "./PrivacyPolicy.css"
 export const metadata = {
   title: "Privacy Policy - Extract from ID Feature | NotaryCentral",
   description:
-    "Learn how your data is handled when using the Extract from ID feature. We prioritize privacy and security in processing your information.",
+    "Learn how your data is handled when using the Extract from ID feature, what information is secured, and the safeguards that protect your privacy at every step of use.",
 }
 
 export default function PrivacyPolicy() {

--- a/app/legal/privacy-policy/page.tsx
+++ b/app/legal/privacy-policy/page.tsx
@@ -4,7 +4,7 @@ import PrivacyPolicyClient from "./PrivacyPolicyClient"
 export const metadata: Metadata = {
   title: "Privacy Policy",
   description:
-    "General. We will not share or sell your personal information or information that can be used to identify you without your permission.",
+    "Learn how NotaryCentral collects, uses, and protects personal information, what data we store, who has access, and your options for managing or deleting it.",
 }
 
 export default function PrivacyPolicy() {

--- a/app/legal/terms-of-use/page.tsx
+++ b/app/legal/terms-of-use/page.tsx
@@ -3,7 +3,8 @@ import TermsOfUseClient from "./TermsOfUseClient"
 
 export const metadata: Metadata = {
   title: "Terms of Service",
-  description: "These terms were updated and effective as of July 31st, 2024",
+  description:
+    "Review NotaryCentral's Terms of Service covering user responsibilities, privacy practices, and liability limits so you know the rules for accessing our tools.",
 }
 
 export default function TermsOfService() {

--- a/app/loan-signings/page.tsx
+++ b/app/loan-signings/page.tsx
@@ -7,7 +7,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Loan Signings",
   description:
-    "Automate loan signing management from email intake to digital journaling and scheduling.",
+    "Automate loan signings from email intake to journaling, mileage logs, and scheduling so every transaction stays organized and compliant from start to finish.",
 }
 
 export default function LoanSigningsPage() {

--- a/app/notary-business-software-ultimate-guide/page.tsx
+++ b/app/notary-business-software-ultimate-guide/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Notary Business Software – Ultimate Guide",
   description:
-    "Modern notary business software bundles scheduling, expense tracking, compliance, and CRM into one workspace.",
+    "See how modern notary software unites scheduling, expense tracking, compliance tools, and CRM features into one platform that streamlines every appointment.",
 }
 
 export default function WhyNotaryCentralFaqPage() {

--- a/app/official-notary-rules/[state]/page.tsx
+++ b/app/official-notary-rules/[state]/page.tsx
@@ -3,6 +3,8 @@ import manuals, { NotaryManual } from "@/lib/notaryManuals"
 
 export const metadata: Metadata = {
   title: "Official notary rules by state",
+  description:
+    "Browse official state notary handbooks and rules in downloadable formats so you can follow the exact laws and procedures for your commission with confidence.",
 }
 
 interface Props {

--- a/app/official-notary-rules/page.tsx
+++ b/app/official-notary-rules/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link"
 
 export const metadata: Metadata = {
   title: "Official notary rules",
+  description:
+    "Browse notary rules for every state with links to journal requirements and legal guidance, helping you understand regulations that govern your commission.",
 }
 
 export default function StateHandbook() {

--- a/app/other-appointments/page.tsx
+++ b/app/other-appointments/page.tsx
@@ -7,7 +7,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Other Appointment Types",
   description:
-    "Handle apostilles, fingerprinting, and custom services with unified intake and billing.",
+    "Manage apostilles, fingerprinting, and custom signings from one dashboard that unifies intake, scheduling, and billing so every specialty job stays organized.",
 }
 
 export default function OtherAppointmentsPage() {

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -37,13 +37,20 @@ export async function generateMetadata({ params }: { params: { slug: string } })
         .map((child: any) => child.text)
         .join("")
         .trim()
-        .slice(0, 155)
     }
   }
 
+  const baseDescription =
+    "Explore this NotaryCentral article for guidance, tips, and compliance insights that help notaries stay organized, secure, and ready for every appointment."
+
+  const description =
+    fallbackDescription && fallbackDescription.length >= 150
+      ? fallbackDescription.slice(0, 160)
+      : baseDescription
+
   return {
     title: `${post.title} | NotaryCentral Blog`,
-    description: fallbackDescription || "Read this article on the NotaryCentral blog",
+    description,
   }
 }
 

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,8 +1,11 @@
-"use client"
-
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardFooter } from "@/components/ui/card"
+import type { Metadata } from "next"
 import PricingView from "@/components/pricing"
+
+export const metadata: Metadata = {
+  title: "Pricing | NotaryCentral",
+  description:
+    "See how NotaryCentral pricing fits your budget with plans that include journals, scheduling, and compliance tools that scale as your notary business grows.",
+}
 
 export default function Pricing() {
 

--- a/app/scheduling/page.tsx
+++ b/app/scheduling/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Effortless Scheduling for Modern Notaries",
   description:
-    "No more missed calls. No more endless phone tag. And no more lost leads from clients who just want to book fast."
+    "Cut missed calls with online scheduling that lets clients book instantly while NotaryCentral syncs calendars, tracks mileage, and keeps appointments organized."
 }
 
 export default function WhyNotaryCentralFaqPage() {

--- a/app/security/account-deletion/page.tsx
+++ b/app/security/account-deletion/page.tsx
@@ -1,6 +1,6 @@
 export const metadata = {
     title: "Account Deletion Information | NotaryCentral",
-    description: "Learn how to delete your NotaryCentral account and understand our data retention policies.",
+    description: "Learn how to delete your NotaryCentral account, what personal data is removed, and how our retention policy works so you can manage information with confidence.",
   }
   
   export default function AccountDeletion() {

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 export const metadata: Metadata = {
   title: "Bank Level Security & Privacy | NotaryCentral",
   description:
-    "We take the security of your data and personal information very seriously. That's why we use advanced digital and physical security measures to ensure your information remains safe and secure.",
+    "NotaryCentral protects your data with digital and physical safeguards so your information and notarization records stay private and accessible only to you.",
 }
 
 export default function SecurityPage() {

--- a/app/signing-services/page.tsx
+++ b/app/signing-services/page.tsx
@@ -4,7 +4,7 @@ import { signingServices } from '@/data/signing-services'
 
 export const metadata: Metadata = {
   title: 'Signing Services & More',
-  description: 'Compilation of signing services, title companies, attorneys and other organizations that work with notaries.'
+  description: 'Browse a curated list of signing services, title companies, and other organizations that hire notaries, with links to research partners and grow business.'
 }
 
 export default function SigningServicesPage() {

--- a/app/training/how-to-use-electronic-journal/head.tsx
+++ b/app/training/how-to-use-electronic-journal/head.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+
+export default function Head() {
+  return (
+    <>
+      <title>Notary Journal Training Path | NotaryCentral</title>
+      <meta
+        name="description"
+        content="Use this NotaryCentral training path to learn the electronic journal, from basic entries to offline mode and thumbprints, linking to articles and quizzes."
+      />
+    </>
+  )
+}

--- a/app/training/intro-quiz/head.tsx
+++ b/app/training/intro-quiz/head.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+
+export default function Head() {
+  return (
+    <>
+      <title>Notary Journal Basics Quiz | NotaryCentral</title>
+      <meta
+        name="description"
+        content="Test your understanding of notary journal basics with this NotaryCentral quiz before creating your first electronic entry and progressing to advanced features."
+      />
+    </>
+  )
+}

--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button"
 
 export const metadata: Metadata = {
   title: "Training Materials - NotaryCentral",
-  description: "Explore available training materials to help you get started with NotaryCentral features.",
+  description:
+    "NotaryCentral training guides you through journals, scheduling, and key tools with tutorials so notaries of any experience work efficiently and stay compliant.",
 }
 
 export default function TrainingMaterials() {

--- a/app/why-notarycentral-is-the-best-us-notary-app/page.tsx
+++ b/app/why-notarycentral-is-the-best-us-notary-app/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next"
 export const metadata: Metadata = {
   title: "Why NotaryCentral is the Best U.S. Notary App: FAQ",
   description:
-    "Frequently asked questions about NotaryCentral and how it streamlines notary work."
+    "Find answers to common questions about NotaryCentral and how it streamlines scheduling, journaling, compliance, and payments into one app for U.S. notaries."
 }
 
 export default function WhyNotaryCentralFaqPage() {


### PR DESCRIPTION
## Summary
- Widen meta descriptions across accounting, legal, training, and resource pages to roughly 150–160 characters for richer search snippets
- Add missing descriptions to dynamic state guides and rules pages so every route offers context for search engines

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*
- `npm run build` *(hangs while creating optimized production build)*

------
https://chatgpt.com/codex/tasks/task_e_689e4c3925bc8323bd9e0a906e43ecc7