### PR TITLE
Rename Products to Supplies and add E&O Insurance resource

### DIFF
--- a/app/e-o-insurance/page.tsx
+++ b/app/e-o-insurance/page.tsx
@@ -1,0 +1,44 @@
+import fs from "fs"
+import path from "path"
+import ReactMarkdown from "react-markdown"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "E&O Insurance",
+  description:
+    "Understand the value of Errors and Omissions insurance for notaries and how to get coverage through our preferred partner, Next Insurance.",
+}
+
+export default function EOInsurancePage() {
+  const markdownPath = path.join(
+    process.cwd(),
+    "data/blog",
+    "e-o-insurance.md"
+  )
+  const markdown = fs.readFileSync(markdownPath, "utf8")
+  const lastUpdatedMatch = markdown.match(
+    /Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/
+  )
+  const isoDate = lastUpdatedMatch
+    ? new Date(lastUpdatedMatch[1]).toISOString()
+    : undefined
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: metadata.title,
+    description: metadata.description,
+    author: { "@type": "Person", name: "Alexander Leon" },
+    datePublished: isoDate,
+    dateModified: isoDate,
+  }
+
+  return (
+    <div className="prose lg:prose-lg dark:prose-invert mx-auto px-4 py-24 md:py-32 max-w-4xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ReactMarkdown>{markdown}</ReactMarkdown>
+    </div>
+  )
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -18,7 +18,7 @@ import { Menu, X } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 
 const menuItems = {
-  products: [
+  supplies: [
     {
       title: "E-Journal",
       description: "Digitally record and store all your notary transactions",
@@ -46,6 +46,10 @@ const menuItems = {
     {
       title: "Why NotaryCentral is the Best US Notary App",
       href: "/why-notarycentral-is-the-best-us-notary-app",
+    },
+    {
+      title: "E&O Insurance",
+      href: "/e-o-insurance",
     },
   ],
 }
@@ -284,10 +288,10 @@ export default function Header() {
                     ))}
                   </div>
 
-                  {/* Show PRODUCTS inline on mobile */}
+                  {/* Show SUPPLIES inline on mobile */}
                   <div className="pt-2 border-t border-gray-700/20 dark:border-gray-500/20">
-                    <h4 className="mb-2 text-md font-semibold">PRODUCTS</h4>
-                    {menuItems.products.map((item) => (
+                    <h4 className="mb-2 text-md font-semibold">SUPPLIES</h4>
+                    {menuItems.supplies.map((item) => (
                       <Link
                         key={item.title}
                         href={item.href}
@@ -396,16 +400,16 @@ export default function Header() {
                 </NavigationMenuList>
               </NavigationMenu>
 
-              {/* Products in a NavigationMenu for desktop */}
+              {/* Supplies in a NavigationMenu for desktop */}
               <NavigationMenu>
                 <NavigationMenuList>
                   <NavigationMenuItem>
                     <NavigationMenuTrigger className="text-sm font-medium bg-transparent hover:bg-transparent hover:text-primary">
-                      PRODUCTS
+                      SUPPLIES
                     </NavigationMenuTrigger>
                     <NavigationMenuContent>
                       <ul className="grid gap-3 p-4 md:w-[400px] lg:w-[500px]">
-                        {menuItems.products.map((item) => (
+                        {menuItems.supplies.map((item) => (
                           <li key={item.title}>
                             <NavigationMenuLink asChild>
                               <Link

--- a/data/blog/e-o-insurance.md
+++ b/data/blog/e-o-insurance.md
@@ -1,0 +1,12 @@
+# E&O Insurance
+**Last updated May 25, 2025**
+
+Errors and Omissions (E&O) insurance protects notaries from financial losses if a mistake or oversight occurs during a notarization. Without coverage, even a minor error could lead to expensive claims or legal fees.
+
+## Why Notaries Need E&O Insurance
+- Covers damages resulting from unintentional mistakes
+- Provides peace of mind so you can focus on serving clients
+- Sometimes required by employers or contracting companies
+
+## Our Preferred Partner
+We've chosen Next Insurance as a preferred partner for E&O insurance for notaries. To get started, follow this link: [Get covered with Next Insurance](https://nextinsurance.sjv.io/c/6459076/1421732/14516).


### PR DESCRIPTION
## Summary
- rename Products navigation to Supplies and include E&O Insurance link under resources
- add E&O Insurance page rendered from markdown with preferred partner Next Insurance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6542819d08323ab295343e71410bc