### PR TITLE
feat: add unique dynamic meta descriptions

### DIFF
--- a/app/how-to-become-a-notary/[state]/page.tsx
+++ b/app/how-to-become-a-notary/[state]/page.tsx
@@ -1,12 +1,5 @@
 import type { Metadata } from 'next'
 import { getStateData } from '@/lib/howToBecome'
-import CompliancePreview from '@/components/CompliancePreview'
-
-export const metadata: Metadata = {
-  title: 'How to become a notary',
-  description:
-    'Learn the steps, eligibility, forms, and resources for becoming a notary in your state so you can start serving clients confidently and stay compliant.',
-}
 
 interface Props {
   params: { state: string }
@@ -17,6 +10,14 @@ function formatStateName(slug: string) {
     .split('-')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ')
+}
+
+export async function generateMetadata({ params }: { params: { state: string } }): Promise<Metadata> {
+  const stateName = formatStateName(params.state)
+  return {
+    title: `How to become a notary in ${stateName}`,
+    description: `Learn the steps, eligibility, forms, and resources for becoming a notary in ${stateName} so you can start serving clients confidently and stay compliant.`,
+  }
 }
 
 // Clean script and style tags out of raw HTML

--- a/app/official-notary-rules/[state]/page.tsx
+++ b/app/official-notary-rules/[state]/page.tsx
@@ -1,22 +1,27 @@
 import type { Metadata } from "next"
 import manuals, { NotaryManual } from "@/lib/notaryManuals"
 
-export const metadata: Metadata = {
-  title: "Official notary rules by state",
-  description:
-    "Browse official state notary handbooks and rules in downloadable formats so you can follow the exact laws and procedures for your commission with confidence.",
-}
-
 interface Props {
   params: { state: string }
 }
 
-export default function OfficialNotaryRulesByState({ params }: Props) {
-  const name = params.state.replace(/-/g, " ")
-  const words = name
-    .split(" ")
+function formatStateName(slug: string) {
+  return slug
+    .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-  const stateName = words.join(" ")
+    .join(" ")
+}
+
+export async function generateMetadata({ params }: { params: { state: string } }): Promise<Metadata> {
+  const stateName = formatStateName(params.state)
+  return {
+    title: `Official notary rules for ${stateName}`,
+    description: `Browse official ${stateName} notary handbooks and rules in downloadable formats so you can follow the exact laws and procedures for your commission with confidence.`,
+  }
+}
+
+export default function OfficialNotaryRulesByState({ params }: Props) {
+  const stateName = formatStateName(params.state)
 
   const stateManuals: NotaryManual[] | undefined = (manuals as any)[params.state]
 

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -24,29 +24,34 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 
   let fallbackDescription = ""
   if (Array.isArray(post.body)) {
-    const paragraphBlock = post.body.find(
+    const blocks = post.body.filter(
       (block) =>
         block._type === "block" &&
         block.style === "normal" &&
         Array.isArray(block.children)
     )
 
-    if (paragraphBlock) {
-      fallbackDescription = paragraphBlock.children
+    for (const block of blocks) {
+      const text = block.children
         .filter((child: any) => child._type === "span")
         .map((child: any) => child.text)
         .join("")
         .trim()
+      if (text) {
+        fallbackDescription += (fallbackDescription ? " " : "") + text
+      }
+      if (fallbackDescription.length >= 150) {
+        break
+      }
     }
   }
 
   const baseDescription =
     "Explore this NotaryCentral article for guidance, tips, and compliance insights that help notaries stay organized, secure, and ready for every appointment."
 
-  const description =
-    fallbackDescription && fallbackDescription.length >= 150
-      ? fallbackDescription.slice(0, 160)
-      : baseDescription
+  const description = fallbackDescription
+    ? fallbackDescription.slice(0, 160)
+    : baseDescription
 
   return {
     title: `${post.title} | NotaryCentral Blog`,


### PR DESCRIPTION
## Summary
- generate unique meta descriptions for blog posts
- tailor state pages with dynamic meta titles and descriptions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2c2351dc8323911096c80e86a704