### PR TITLE
feat: include local markdown posts in blog

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,3 +1,5 @@
+import fs from "fs"
+import path from "path"
 import Link from "next/link"
 import Image from "next/image"
 import { getPosts, urlFor } from "@/lib/sanity"
@@ -7,6 +9,45 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from "@/components/ui/button"
 import { ChevronRight } from "lucide-react"
 
+type BlogPost = Post & { href: string }
+
+function getLocalPosts(): Post[] {
+  const postsDir = path.join(process.cwd(), "data", "blog")
+  const files = fs.readdirSync(postsDir).filter((file) => file.endsWith(".md"))
+
+  return files.map((file) => {
+    const filePath = path.join(postsDir, file)
+    const slug = file.replace(/\.md$/, "")
+    const markdown = fs.readFileSync(filePath, "utf8")
+    const titleMatch = markdown.match(/^#\s+(.*)/)
+    const title = titleMatch ? titleMatch[1].trim() : slug
+
+    const content = markdown.replace(/^#.*\n/, "").trim()
+    const excerptLine = content.split("\n").find((line) => line.trim()) || ""
+    const excerpt =
+      excerptLine.length > 140 ? `${excerptLine.slice(0, 137).trim()}...` : excerptLine
+
+    const dateMatch = markdown.match(
+      /Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/i
+    )
+    const stats = fs.statSync(filePath)
+    const publishedAt = dateMatch
+      ? new Date(dateMatch[1]).toISOString()
+      : stats.mtime.toISOString()
+
+    return {
+      _id: slug,
+      title,
+      slug: { current: slug },
+      mainImage: null,
+      publishedAt,
+      excerpt,
+      author: { name: "NotaryCentral", image: null },
+      categories: [],
+    } as Post
+  })
+}
+
 export const metadata = {
   title: "Blog | NotaryCentral",
   description:
@@ -14,7 +55,23 @@ export const metadata = {
 }
 
 export default async function BlogPage() {
-  const posts = (await getPosts()) as Post[]
+  const sanityPosts = (await getPosts()) as Post[]
+  const localPosts = getLocalPosts()
+
+  const posts: BlogPost[] = [
+    ...sanityPosts.map((p) => ({
+      ...p,
+      href: `/post/${p.slug.current}`,
+    })),
+    ...localPosts.map((p) => ({
+      ...p,
+      href: `/${p.slug.current}`,
+    })),
+  ].sort((a, b) => {
+    const dateA = a.publishedAt ? new Date(a.publishedAt).getTime() : 0
+    const dateB = b.publishedAt ? new Date(b.publishedAt).getTime() : 0
+    return dateB - dateA
+  })
 
   return (
     <div className="container mx-auto px-4 py-24 md:py-32">
@@ -24,7 +81,7 @@ export default async function BlogPage() {
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-        {posts?.map((post) => (
+        {posts.map((post) => (
           <Card key={post._id} className="overflow-hidden flex flex-col h-full">
             <div className="relative h-48 w-full">
               {post.mainImage && (
@@ -47,7 +104,7 @@ export default async function BlogPage() {
             <CardContent className="flex-grow">{/* Content goes here if needed */}</CardContent>
             <CardFooter>
               <Button variant="outline" size="sm" asChild className="group">
-                <Link href={`/post/${post.slug.current}`}>
+                <Link href={post.href}>
                   Read More
                   <ChevronRight className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </Link>


### PR DESCRIPTION
## Summary
- Load markdown articles from `data/blog` and merge them with Sanity posts on the `/blog` page
- Parse basic metadata from local files and generate correct links

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to load config "next/core-web-vitals" to extend from)


------
https://chatgpt.com/codex/tasks/task_e_68b9fc8678a48323869428106339b64f