### PR TITLE
Combine e-journal rules with location selector

### DIFF
--- a/app/e-journal/page.tsx
+++ b/app/e-journal/page.tsx
@@ -3,8 +3,6 @@ import path from "path"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import type { Metadata } from "next"
-import CountryAndRegionPicker from "@/components/CountryAndRegionPicker"
-import StateCompliance from "@/components/StateCompliance"
 import EJournalStateInfo from "@/components/EJournalStateInfo"
 
 export const metadata: Metadata = {
@@ -44,7 +42,6 @@ export default function EJournalPage() {
         <div className="mt-12 space-y-12">
           <EJournalStateInfo />
         </div>
-        <CountryAndRegionPicker />
         <div className="relative w-full max-w-2xl mx-auto my-8 aspect-video">
           <iframe
             src="https://www.youtube.com/embed/yUQsJw9C_g4"

--- a/components/EJournalStateInfo.tsx
+++ b/components/EJournalStateInfo.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle, XCircle } from "lucide-react"
 import { useLocation } from "./LocationProvider"
 import { eJournalStateData, type EJournalStateInfo } from "@/data/e-journal-state-data"
+import CountryAndRegionPicker from "@/components/CountryAndRegionPicker"
 
 const STATE_MAP: Record<string, string> = {
   AL: "Alabama", AK: "Alaska", AZ: "Arizona", AR: "Arkansas", CA: "California",
@@ -32,19 +33,22 @@ export default function EJournalStateInfo() {
 
   return (
     <section className="py-6 border-t border-gray-200 dark:border-gray-800 bg-secondary dark:bg-gray-900">
-      <div className="container mx-auto px-4 text-center space-y-3">
-        <h2 className="text-2xl md:text-3xl font-bold">
-          Electronic journal rules in {stateName}
-        </h2>
-        <p className={`text-lg ${color}`}>
-          <Icon className="inline-block mr-1 h-5 w-5" />
-          {info.value ? "An electronic journal may be used exclusively." : "A paper journal is required."}
-        </p>
-        <p className="text-sm">
-          <a href={info.link} className="underline" target="_blank" rel="noopener noreferrer">
-            {info.citation}
-          </a>
-        </p>
+      <div className="container mx-auto px-4 text-center space-y-6">
+        <div className="space-y-3">
+          <h2 className="text-2xl md:text-3xl font-bold">
+            Electronic journal rules in {stateName}
+          </h2>
+          <p className={`text-lg ${color}`}>
+            <Icon className="inline-block mr-1 h-5 w-5" />
+            {info.value ? "An electronic journal may be used exclusively." : "A paper journal is required."}
+          </p>
+          <p className="text-sm">
+            <a href={info.link} className="underline" target="_blank" rel="noopener noreferrer">
+              {info.citation}
+            </a>
+          </p>
+        </div>
+        <CountryAndRegionPicker />
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- embed the state/country picker directly in the e-journal rules section
- remove standalone picker usage on the e-journal page

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bba3736a0c8323927aa2c42db9b2d0