### PR TITLE
Redirect e-journal state changes to state-specific URLs

### DIFF
--- a/components/CountryAndRegionPicker.tsx
+++ b/components/CountryAndRegionPicker.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Card, CardContent } from "@/components/ui/card"
+import { maybeRedirectToStatePage } from "@/lib/state-url"
 
 // State name to abbreviation mapping
 const stateNameToAbbreviation = {
@@ -216,7 +217,9 @@ export default function CountryAndRegionPicker({
     locationEventBus.publish({ country, region: defaultRegion })
     onChange?.({ country, region: defaultRegion })
 
-    window.location.reload()
+    if (!maybeRedirectToStatePage(defaultRegion)) {
+      window.location.reload()
+    }
   }
 
   const handleRegionChange = (region: string) => {
@@ -226,7 +229,9 @@ export default function CountryAndRegionPicker({
     locationEventBus.publish({ country: selectedCountry, region })
     onChange?.({ country: selectedCountry, region })
 
-    window.location.reload()
+    if (!maybeRedirectToStatePage(region)) {
+      window.location.reload()
+    }
   }
 
   if (loading) {

--- a/components/StatePicker.tsx
+++ b/components/StatePicker.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { canadianProvinces, locationEventBus } from "./CountryAndRegionPicker"
+import { maybeRedirectToStatePage } from "@/lib/state-url"
 
 export default function StatePicker() {
   const [state, setState] = useState("CA")
@@ -97,8 +98,10 @@ export default function StatePicker() {
     // Notify other components about the location change
     locationEventBus.publish({ country, region: newState })
 
-    // Refresh the page when the state changes
-    window.location.reload()
+    if (!maybeRedirectToStatePage(newState)) {
+      // Refresh the page when no route-based redirect occurs
+      window.location.reload()
+    }
   }
 
   return (

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -16,6 +16,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { cn } from "@/lib/utils"
 import { Menu, X } from "lucide-react"
 import { useLocation } from "@/components/LocationProvider"
+import { maybeRedirectToStatePage } from "@/lib/state-url"
 
 const menuItems = {
   supplies: [
@@ -180,12 +181,16 @@ export default function Header() {
   const handleCountryChange = (newCountry: string) => {
     const defaultRegion = newCountry === "US" ? "CA" : "BC"
     setLocation(newCountry, defaultRegion)
-    window.location.reload()
+    if (!maybeRedirectToStatePage(defaultRegion)) {
+      window.location.reload()
+    }
   }
 
   const handleStateChange = (newState: string) => {
     setLocation(country, newState)
-    window.location.reload()
+    if (!maybeRedirectToStatePage(newState)) {
+      window.location.reload()
+    }
   }
 
   return (

--- a/lib/state-url.ts
+++ b/lib/state-url.ts
@@ -1,0 +1,34 @@
+import { STATE_MAP } from "./states"
+
+interface StateRoute {
+  pattern: RegExp
+  build: (slug: string) => string
+}
+
+const routes: StateRoute[] = [
+  {
+    pattern: /^\/(?:[a-z-]+\/)?e-journal\/?$/,
+    build: (slug) => `/${slug}/e-journal`,
+  },
+]
+
+export function maybeRedirectToStatePage(abbr: string): boolean {
+  if (typeof window === "undefined") return false
+
+  const slug = STATE_MAP[abbr]?.toLowerCase().replace(/\s+/g, "-") || abbr.toLowerCase()
+  const { pathname } = window.location
+
+  for (const route of routes) {
+    if (route.pattern.test(pathname)) {
+      const target = route.build(slug)
+      if (pathname !== target) {
+        window.location.href = target
+      } else {
+        window.location.reload()
+      }
+      return true
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary
- Add reusable state-based redirect utility
- Update header, CountryAndRegionPicker, and StatePicker to use state redirects

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2f2df6f88323980ba32289ecdf15