### PR TITLE
Avoid full page reload on country change

### DIFF
--- a/components/CountryAndRegionPicker.tsx
+++ b/components/CountryAndRegionPicker.tsx
@@ -215,10 +215,6 @@ export default function CountryAndRegionPicker({
 
     locationEventBus.publish({ country, region: defaultRegion })
     onChange?.({ country, region: defaultRegion })
-
-    if (!maybeRedirectToStatePage(defaultRegion)) {
-      window.location.reload()
-    }
   }
 
   const handleRegionChange = (region: string) => {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -181,9 +181,6 @@ export default function Header() {
   const handleCountryChange = (newCountry: string) => {
     const defaultRegion = newCountry === "US" ? "CA" : "BC"
     setLocation(newCountry, defaultRegion)
-    if (!maybeRedirectToStatePage(defaultRegion)) {
-      window.location.reload()
-    }
   }
 
   const handleStateChange = (newState: string) => {


### PR DESCRIPTION
## Summary
- stop header country switcher from reloading the page
- remove reload logic from CountryAndRegionPicker country selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3416c40483238a87ea6e604402d3