### PR TITLE
feat: support state-specific e-journal PDF

### DIFF
--- a/components/EJournalPageContent.tsx
+++ b/components/EJournalPageContent.tsx
@@ -12,7 +12,12 @@ interface Props {
 
 export default function EJournalPageContent({ title, description, stateAbbreviation }: Props) {
   const markdownPath = path.join(process.cwd(), "data/blog", "e-journal.md")
-  const markdown = fs.readFileSync(markdownPath, "utf8")
+  const markdownFile = fs.readFileSync(markdownPath, "utf8")
+  const pdfSuffix = stateAbbreviation ? `-${stateAbbreviation.toLowerCase()}` : ""
+  const markdown = markdownFile.replace(
+    /\/blog-pdf\/ejournal\.pdf/g,
+    `/blog-pdf/ejournal${pdfSuffix}.pdf`,
+  )
   const [intro, rest] = markdown.split("<!--STATE_PICKER-->")
   const introWithoutHeading = intro.replace(/^# .+\n/, "")
   const lastUpdatedMatch = markdown.match(/Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/)


### PR DESCRIPTION
## Summary
- dynamically rewrite e-journal PDF link based on state abbreviation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc34d6b4e083239f96cd10b2b90708