### PR TITLE
feat: add e-journal pricing section

### DIFF
--- a/app/e-journal/page.tsx
+++ b/app/e-journal/page.tsx
@@ -21,21 +21,31 @@ export const metadata: Metadata = {
 export default function EJournalPage() {
   // Load & slice the markdown into sections using markers
   let intro = ""
-  let beforeDevices = ""
+  let beforePricing = ""
+  let afterPricing = ""
   let afterDevices = ""
   let isoDate: string | undefined
 
   try {
     const markdownPath = path.join(process.cwd(), "data/blog", "e-journal.md")
     const markdown = fs.readFileSync(markdownPath, "utf8")
+    const pricingMarker = "<!--PRICING-->"
+    const markdownWithPricing = markdown.replace(
+      "[See pricing.](https://www.notarycentral.org/pricing)",
+      pricingMarker,
+    )
 
-    const [introPart, rest = ""] = markdown.split("<!--STATE_PICKER-->")
+    const [introPart, rest = ""] = markdownWithPricing.split("<!--STATE_PICKER-->")
     intro = introPart || ""
 
     const [beforeDevicesPart, afterDevicesPart = ""] = rest.split(
       "<!--WORKS_ON_DEVICES-->"
     )
-    beforeDevices = beforeDevicesPart || ""
+    const [beforePricingPart, afterPricingPart = ""] = beforeDevicesPart.split(
+      pricingMarker
+    )
+    beforePricing = beforePricingPart || ""
+    afterPricing = afterPricingPart || ""
     afterDevices = afterDevicesPart || ""
 
     const lastUpdatedMatch = markdown.match(
@@ -84,8 +94,12 @@ export default function EJournalPage() {
             />
           </div>
 
-          {beforeDevices && (
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{beforeDevices}</ReactMarkdown>
+          {beforePricing && (
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{beforePricing}</ReactMarkdown>
+          )}
+          <PricingView showJournalOnly />
+          {afterPricing && (
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{afterPricing}</ReactMarkdown>
           )}
 
           <WorksOnDevices />
@@ -95,7 +109,6 @@ export default function EJournalPage() {
           )}
         </div>
       </div>
-      <PricingView />
     </>
   )
 }

--- a/app/e-journal/page.tsx
+++ b/app/e-journal/page.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm"
 
 import EJournalStateInfo from "@/components/EJournalStateInfo"
 import WorksOnDevices from "@/components/WorksOnDevices"
+import PricingView from "@/components/pricing"
 
 const title = "Electronic Journal (e-Journal)"
 const description =
@@ -58,40 +59,43 @@ export default function EJournalPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-24 md:py-32">
-      <div className="prose lg:prose-lg dark:prose-invert mx-auto max-w-4xl">
-        <script
-          type="application/ld+json"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
-        {intro && <ReactMarkdown remarkPlugins={[remarkGfm]}>{intro}</ReactMarkdown>}
-
-        <div className="mt-12 space-y-12">
-          <EJournalStateInfo />
-        </div>
-
-        <div className="relative w-full max-w-2xl mx-auto my-8 aspect-video">
-          <iframe
-            src="https://www.youtube.com/embed/yUQsJw9C_g4"
-            title="Electronic journal overview"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            referrerPolicy="strict-origin-when-cross-origin"
-            allowFullScreen
-            className="absolute inset-0 h-full w-full rounded-lg shadow-lg"
+    <>
+      <div className="container mx-auto px-4 py-24 md:py-32">
+        <div className="prose lg:prose-lg dark:prose-invert mx-auto max-w-4xl">
+          <script
+            type="application/ld+json"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
           />
+          {intro && <ReactMarkdown remarkPlugins={[remarkGfm]}>{intro}</ReactMarkdown>}
+
+          <div className="mt-12 space-y-12">
+            <EJournalStateInfo />
+          </div>
+
+          <div className="relative w-full max-w-2xl mx-auto my-8 aspect-video">
+            <iframe
+              src="https://www.youtube.com/embed/yUQsJw9C_g4"
+              title="Electronic journal overview"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allowFullScreen
+              className="absolute inset-0 h-full w-full rounded-lg shadow-lg"
+            />
+          </div>
+
+          {beforeDevices && (
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{beforeDevices}</ReactMarkdown>
+          )}
+
+          <WorksOnDevices />
+
+          {afterDevices && (
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{afterDevices}</ReactMarkdown>
+          )}
         </div>
-
-        {beforeDevices && (
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{beforeDevices}</ReactMarkdown>
-        )}
-
-        <WorksOnDevices />
-
-        {afterDevices && (
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{afterDevices}</ReactMarkdown>
-        )}
       </div>
-    </div>
+      <PricingView />
+    </>
   )
 }

--- a/components/EJournalPageContent.tsx
+++ b/components/EJournalPageContent.tsx
@@ -3,6 +3,7 @@ import path from "path"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import EJournalStateInfo from "@/components/EJournalStateInfo"
+import PricingView from "@/components/pricing"
 
 interface Props {
   title: string
@@ -33,30 +34,33 @@ export default function EJournalPageContent({ title, description, stateAbbreviat
   }
 
   return (
-    <div className="container mx-auto px-4 py-24 md:py-32">
-      <div className="prose lg:prose-lg dark:prose-invert mx-auto max-w-4xl">
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
-        <h1>{title}</h1>
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{introWithoutHeading}</ReactMarkdown>
-        <div className="mt-12 space-y-12">
-          <EJournalStateInfo stateAbbreviation={stateAbbreviation} />
-        </div>
-        <div className="relative w-full max-w-2xl mx-auto my-8 aspect-video">
-          <iframe
-            src="https://www.youtube.com/embed/yUQsJw9C_g4"
-            title="Electronic journal overview"
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-            className="absolute inset-0 w-full h-full rounded-lg shadow-lg"
+    <>
+      <div className="container mx-auto px-4 py-24 md:py-32">
+        <div className="prose lg:prose-lg dark:prose-invert mx-auto max-w-4xl">
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
           />
+          <h1>{title}</h1>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{introWithoutHeading}</ReactMarkdown>
+          <div className="mt-12 space-y-12">
+            <EJournalStateInfo stateAbbreviation={stateAbbreviation} />
+          </div>
+          <div className="relative w-full max-w-2xl mx-auto my-8 aspect-video">
+            <iframe
+              src="https://www.youtube.com/embed/yUQsJw9C_g4"
+              title="Electronic journal overview"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className="absolute inset-0 w-full h-full rounded-lg shadow-lg"
+            />
+          </div>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{rest}</ReactMarkdown>
         </div>
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{rest}</ReactMarkdown>
-      </div>
 
-    </div>
+      </div>
+      <PricingView />
+    </>
   )
 }

--- a/components/EJournalPageContent.tsx
+++ b/components/EJournalPageContent.tsx
@@ -15,11 +15,17 @@ export default function EJournalPageContent({ title, description, stateAbbreviat
   const markdownPath = path.join(process.cwd(), "data/blog", "e-journal.md")
   const markdownFile = fs.readFileSync(markdownPath, "utf8")
   const pdfSuffix = stateAbbreviation ? `${stateAbbreviation.toLowerCase()}` : ""
-  const markdown = markdownFile.replace(
+  const pricingMarker = "<!--PRICING-->"
+  const markdownWithPricing = markdownFile.replace(
+    "[See pricing.](https://www.notarycentral.org/pricing)",
+    pricingMarker,
+  )
+  const markdown = markdownWithPricing.replace(
     /\/blog-pdf\/ejournal\.pdf/g,
     `/blog-pdf/ejournal/${pdfSuffix}.pdf`,
   )
-  const [intro, rest] = markdown.split("<!--STATE_PICKER-->")
+  const [intro, restWithPricing] = markdown.split("<!--STATE_PICKER-->")
+  const [beforePricing, afterPricing] = restWithPricing.split(pricingMarker)
   const introWithoutHeading = intro.replace(/^# .+\n/, "")
   const lastUpdatedMatch = markdown.match(/Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/)
   const isoDate = lastUpdatedMatch ? new Date(lastUpdatedMatch[1]).toISOString() : undefined
@@ -56,11 +62,12 @@ export default function EJournalPageContent({ title, description, stateAbbreviat
               className="absolute inset-0 w-full h-full rounded-lg shadow-lg"
             />
           </div>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{rest}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{beforePricing}</ReactMarkdown>
+          <PricingView showJournalOnly />
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{afterPricing}</ReactMarkdown>
         </div>
 
       </div>
-      <PricingView />
     </>
   )
 }

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -21,21 +21,28 @@ export default function Pricing() {
   const [journalAnnual, setJournalAnnual] = useState(true)
   const [businessAnnual, setBusinessAnnual] = useState(true)
 
+  const freeJournalPlan = {
+    name: "Free",
+    description: "Start with your first 5 entries free",
+    badge: "No credit card required",
+    features: ["Digital e-Journal", "Mobile app access", "Email support"],
+  }
+
   const journalPlans = {
     monthly: {
-      name: "Journal (Monthly)",
+      name: "Plus (Monthly)",
       price: 1.95,
       billing: "month",
-      description: "Digital journal for notaries on the go",
-      badge: "First 5 entries free",
+      description: "Unlimited entries and full access",
+      badge: "Unlimited entries",
       features: ["Digital e-Journal", "Mobile app access", "Email support"],
     },
     yearly: {
-      name: "Journal (Yearly)",
+      name: "Plus (Yearly)",
       price: 19.95,
       billing: "year",
-      description: "Save more with the annual journal subscription",
-      badge: "First 5 entries free",
+      description: "Unlimited entries and full access",
+      badge: "Unlimited entries",
       features: ["Digital e-Journal", "Mobile app access", "Email support"],
     },
   }
@@ -173,7 +180,37 @@ export default function Pricing() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-1 max-w-3xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5 }}
+              className="bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden"
+            >
+              <div className="p-8">
+                <h4 className="text-xl font-bold mb-2">{freeJournalPlan.name}</h4>
+                <p className="text-muted-foreground mb-2">{freeJournalPlan.description}</p>
+                <span className="inline-block text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100 px-2 py-1 rounded-full mb-4">
+                  {freeJournalPlan.badge}
+                </span>
+                <div className="mb-6">
+                  <span className="text-3xl font-bold">Free</span>
+                </div>
+                <Button onClick={onStart} className="w-full mb-6" variant="outline">
+                  Start for Free
+                </Button>
+                <ul className="space-y-3">
+                  {freeJournalPlan.features.map((feature, i) => (
+                    <li key={i} className="flex items-start">
+                      <Check className="h-5 w-5 text-green-500 mr-2 shrink-0" />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </motion.div>
+
             {(() => {
               const plan = journalAnnual ? journalPlans.yearly : journalPlans.monthly
               return (

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -7,7 +7,15 @@ import { Check } from "lucide-react"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 
-export default function Pricing() {
+interface Props {
+  /**
+   * When true, only e-Journal plans are shown and the Business Tools
+   * section is hidden.
+   */
+  showJournalOnly?: boolean
+}
+
+export default function Pricing({ showJournalOnly = false }: Props) {
   const ref = useRef(null)
   const { scrollYProgress } = useScroll({
     target: ref,
@@ -97,71 +105,73 @@ export default function Pricing() {
 
         
         {/* Business Tools Section */}
-        <div>
-          <div className="flex items-center justify-center space-x-4 mb-6">
-            <Label htmlFor="business-toggle" className={businessAnnual ? "text-muted-foreground" : "font-medium"}>
-              Monthly
-            </Label>
-            <Switch id="business-toggle" checked={businessAnnual} onCheckedChange={setBusinessAnnual} />
-            <div className="flex items-center">
-              <Label htmlFor="business-toggle" className={businessAnnual ? "font-medium" : "text-muted-foreground"}>
-                Annual
+        {!showJournalOnly && (
+          <div>
+            <div className="flex items-center justify-center space-x-4 mb-6">
+              <Label htmlFor="business-toggle" className={businessAnnual ? "text-muted-foreground" : "font-medium"}>
+                Monthly
               </Label>
-              <span className="ml-2 text-xs bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100 px-2 py-1 rounded-full">
-                Save 20%
-              </span>
+              <Switch id="business-toggle" checked={businessAnnual} onCheckedChange={setBusinessAnnual} />
+              <div className="flex items-center">
+                <Label htmlFor="business-toggle" className={businessAnnual ? "font-medium" : "text-muted-foreground"}>
+                  Annual
+                </Label>
+                <span className="ml-2 text-xs bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100 px-2 py-1 rounded-full">
+                  Save 20%
+                </span>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-1 max-w-3xl mx-auto">
+              {(() => {
+                const plan = businessAnnual ? businessPlans.yearly : businessPlans.monthly
+                return (
+                  <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.5 }}
+                    className={`bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden ${
+                      !businessAnnual && businessPlans.monthly.popular ? "ring-2 ring-primary relative" : ""
+                    }`}
+                  >
+                    {!businessAnnual && businessPlans.monthly.popular && (
+                      <div className="bg-primary text-primary-foreground text-xs font-semibold px-3 py-1 absolute right-0 top-0 rounded-bl-lg">
+                        MOST POPULAR
+                      </div>
+                    )}
+                    <div className="p-8">
+                      <h4 className="text-xl font-bold mb-2">{plan.name}</h4>
+                      <p className="text-muted-foreground mb-2">{plan.description}</p>
+                      <span className="inline-block text-xs font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100 px-2 py-1 rounded-full mb-4">
+                        {plan.badge}
+                      </span>
+                      <div className="mb-6">
+                        <span className="text-3xl font-bold">
+                          {plan.billing === "year" ? `$${(plan.price / 12).toFixed(2)}` : `$${plan.price}`}
+                        </span>
+                        <span className="text-muted-foreground">
+                          /month{plan.billing === "year" && <span className="text-sm"> (billed annually)</span>}
+                        </span>
+                      </div>
+                      <Button onClick={onStart} className="w-full mb-6" variant={businessAnnual ? "outline" : "default"}>
+                        Get Started
+                      </Button>
+                      <ul className="space-y-3">
+                        {plan.features.map((feature, i) => (
+                          <li key={i} className="flex items-start">
+                            <Check className="h-5 w-5 text-green-500 mr-2 shrink-0" />
+                            <span>{feature}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </motion.div>
+                )
+              })()}
             </div>
           </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-1 max-w-3xl mx-auto">
-            {(() => {
-              const plan = businessAnnual ? businessPlans.yearly : businessPlans.monthly
-              return (
-                <motion.div
-                  initial={{ opacity: 0, y: 20 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true }}
-                  transition={{ duration: 0.5 }}
-                  className={`bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden ${
-                    !businessAnnual && businessPlans.monthly.popular ? "ring-2 ring-primary relative" : ""
-                  }`}
-                >
-                  {!businessAnnual && businessPlans.monthly.popular && (
-                    <div className="bg-primary text-primary-foreground text-xs font-semibold px-3 py-1 absolute right-0 top-0 rounded-bl-lg">
-                      MOST POPULAR
-                    </div>
-                  )}
-                  <div className="p-8">
-                    <h4 className="text-xl font-bold mb-2">{plan.name}</h4>
-                    <p className="text-muted-foreground mb-2">{plan.description}</p>
-                    <span className="inline-block text-xs font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100 px-2 py-1 rounded-full mb-4">
-                      {plan.badge}
-                    </span>
-                    <div className="mb-6">
-                      <span className="text-3xl font-bold">
-                        {plan.billing === "year" ? `$${(plan.price / 12).toFixed(2)}` : `$${plan.price}`}
-                      </span>
-                      <span className="text-muted-foreground">
-                        /month{plan.billing === "year" && <span className="text-sm"> (billed annually)</span>}
-                      </span>
-                    </div>
-                    <Button onClick={onStart} className="w-full mb-6" variant={businessAnnual ? "outline" : "default"}>
-                      Get Started
-                    </Button>
-                    <ul className="space-y-3">
-                      {plan.features.map((feature, i) => (
-                        <li key={i} className="flex items-start">
-                          <Check className="h-5 w-5 text-green-500 mr-2 shrink-0" />
-                          <span>{feature}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </motion.div>
-              )
-            })()}
-          </div>
-        </div>
+        )}
 
         {/* Journal Section */}
         <div className="mb-16">


### PR DESCRIPTION
## Summary
- show free and plus journal tiers in shared pricing component
- display pricing on `/e-journal` and each state e-journal page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8f9387dc8323959799fc4c1af3d7