### PR TITLE
feat: mention digital notary tracker in business suite

### DIFF
--- a/app/business-management-suite/page.tsx
+++ b/app/business-management-suite/page.tsx
@@ -4,13 +4,18 @@ import { useCases, features } from "@/data/business-management-suite"
 
 export const metadata: Metadata = {
   title: "Business Management Suite | NotaryCentral",
-  description: "Explore the use cases and features of the NotaryCentral Business Management Suite.",
+  description:
+    "Explore the use cases and features of the NotaryCentral Business Management Suite, the digital notary tracker built for notaries.",
 }
 
 export default function BusinessManagementSuitePage() {
   return (
     <div className="container mx-auto px-4 py-24 md:py-32">
       <h1 className="mb-8 text-3xl font-bold">Business Management Suite</h1>
+      <p className="mb-12 text-lg text-muted-foreground">
+        Manage appointments, expenses, and client details with NotaryCentral's
+        Business Management Suite, your digital notary tracker.
+      </p>
 
       <section className="mb-12">
         <h2 className="mb-4 text-2xl font-semibold">Use Cases</h2>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -27,7 +27,7 @@ const menuItems = {
     },
     {
       title: "Business Management Suite",
-      description: "Manage scheduling, expenses, and more from one place",
+      description: "The digital notary tracker for managing scheduling, expenses, and clients",
       href: "/business-management-suite",
     },
   ],


### PR DESCRIPTION
## Summary
- highlight Business Management Suite as the digital notary tracker in page metadata and intro
- describe navigation menu entry as the digital notary tracker for scheduling, expenses, and clients

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bde35f4618832383c6d832ab454aca