### PR TITLE
feat(blog): add tag filtering

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,13 +1,8 @@
 import fs from "fs"
 import path from "path"
-import Link from "next/link"
-import Image from "next/image"
-import { getPosts, urlFor } from "@/lib/sanity"
+import { getPosts } from "@/lib/sanity"
 import type { Post } from "@/types/post"
-import { format } from "date-fns"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { ChevronRight } from "lucide-react"
+import PostList from "./post-list"
 
 type BlogPost = Post & { href: string }
 
@@ -22,7 +17,17 @@ function getLocalPosts(): Post[] {
     const titleMatch = markdown.match(/^#\s+(.*)/)
     const title = titleMatch ? titleMatch[1].trim() : slug
 
-    const content = markdown.replace(/^#.*\n/, "").trim()
+    const contentWithoutTitle = markdown.replace(/^#.*\n/, "")
+    const tagsMatch = contentWithoutTitle.match(/^Tags:\s*(.+)$/mi)
+    const categories = tagsMatch
+      ? tagsMatch[1].split(",").map((tag) => tag.trim())
+      : []
+
+    const content = contentWithoutTitle
+      .replace(/^Last updated.*\n/i, "")
+      .replace(/^Tags:.*\n/i, "")
+      .trim()
+
     const excerptLine = content.split("\n").find((line) => line.trim()) || ""
     const excerpt =
       excerptLine.length > 140 ? `${excerptLine.slice(0, 137).trim()}...` : excerptLine
@@ -43,7 +48,7 @@ function getLocalPosts(): Post[] {
       publishedAt,
       excerpt,
       author: { name: "NotaryCentral", image: null },
-      categories: [],
+      categories,
     } as Post
   })
 }
@@ -73,46 +78,5 @@ export default async function BlogPage() {
     return dateB - dateA
   })
 
-  return (
-    <div className="container mx-auto px-4 py-24 md:py-32">
-      <div className="max-w-3xl mx-auto mb-16 text-center">
-        <h1 className="text-4xl font-bold mb-4">NotaryCentral Blog</h1>
-        <p className="text-xl text-muted-foreground">Latest news, tips, and updates for notaries</p>
-      </div>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-        {posts.map((post) => (
-          <Card key={post._id} className="overflow-hidden flex flex-col h-full">
-            <div className="relative h-48 w-full">
-              {post.mainImage && (
-                <Image
-                  src={urlFor(post.mainImage).url() || "/placeholder.svg"}
-                  alt={post.title}
-                  fill
-                  className="object-cover"
-                />
-              )}
-            </div>
-            <CardHeader>
-              <div className="text-sm text-muted-foreground mb-2">
-                {post.publishedAt && format(new Date(post.publishedAt), "MMMM dd, yyyy")}
-                {post.categories && post.categories.length > 0 && <span> · {post.categories.join(", ")}</span>}
-              </div>
-              <CardTitle className="text-xl">{post.title}</CardTitle>
-              <CardDescription>{post.excerpt}</CardDescription>
-            </CardHeader>
-            <CardContent className="flex-grow">{/* Content goes here if needed */}</CardContent>
-            <CardFooter>
-              <Button variant="outline" size="sm" asChild className="group">
-                <Link href={post.href}>
-                  Read More
-                  <ChevronRight className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" />
-                </Link>
-              </Button>
-            </CardFooter>
-          </Card>
-        ))}
-      </div>
-    </div>
-  )
+  return <PostList posts={posts} />
 }

--- a/app/blog/post-list.tsx
+++ b/app/blog/post-list.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { format } from 'date-fns'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { ChevronRight } from 'lucide-react'
+import { urlFor } from '@/lib/sanity'
+import type { Post } from '@/types/post'
+
+type BlogPost = Post & { href: string }
+
+export default function PostList({ posts }: { posts: BlogPost[] }) {
+  const allTags = Array.from(new Set(posts.flatMap((p) => p.categories || [])))
+  const tagOptions = ['All', ...allTags]
+  const [selectedTag, setSelectedTag] = useState('All')
+  const filteredPosts =
+    selectedTag === 'All'
+      ? posts
+      : posts.filter((p) => (p.categories || []).includes(selectedTag))
+
+  return (
+    <div className="container mx-auto px-4 py-24 md:py-32">
+      <div className="max-w-3xl mx-auto mb-16 text-center">
+        <h1 className="text-4xl font-bold mb-4">NotaryCentral Blog</h1>
+        <p className="text-xl text-muted-foreground">
+          Latest news, tips, and updates for notaries
+        </p>
+        {tagOptions.length > 1 && (
+          <div className="mt-4 flex justify-center">
+            <Select value={selectedTag} onValueChange={setSelectedTag}>
+              <SelectTrigger className="w-[250px]">
+                <SelectValue placeholder="Filter by tag" />
+              </SelectTrigger>
+              <SelectContent>
+                {tagOptions.map((tag) => (
+                  <SelectItem key={tag} value={tag}>
+                    {tag}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        {filteredPosts.map((post) => (
+          <Card key={post._id} className="overflow-hidden flex flex-col h-full">
+            <div className="relative h-48 w-full">
+              {post.mainImage && (
+                <Image
+                  src={urlFor(post.mainImage).url() || '/placeholder.svg'}
+                  alt={post.title}
+                  fill
+                  className="object-cover"
+                />
+              )}
+            </div>
+            <CardHeader>
+              <div className="text-sm text-muted-foreground mb-2">
+                {post.publishedAt &&
+                  format(new Date(post.publishedAt), 'MMMM dd, yyyy')}
+                {post.categories && post.categories.length > 0 && (
+                  <span> · {post.categories.join(', ')}</span>
+                )}
+              </div>
+              <CardTitle className="text-xl">{post.title}</CardTitle>
+              <CardDescription>{post.excerpt}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex-grow">{/* Content goes here if needed */}</CardContent>
+            <CardFooter>
+              <Button variant="outline" size="sm" asChild className="group">
+                <Link href={post.href}>
+                  Read More
+                  <ChevronRight className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" />
+                </Link>
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/data/blog/about.md
+++ b/data/blog/about.md
@@ -2,8 +2,10 @@
 
 [▶︎ Download the PDF version](/blog-pdf/about.pdf)
 
-**Alexander Leon**  
+**Alexander Leon**
 Last updated August 3, 2025
+
+Tags: Rules & Regulations
 
 ## A Mission Rooted in Innovation
 

--- a/data/blog/ask-ai.md
+++ b/data/blog/ask-ai.md
@@ -2,6 +2,8 @@
 
 [▶︎ Download the PDF version](/blog-pdf/ask-ai.pdf)
 
+Tags: Rules & Regulations
+
 Notaries work under regulations that change from state to state. Keeping track of each jurisdiction’s laws and procedures can be daunting—especially when the answer can be buried in pages of statutes or policy manuals. That’s why NotaryCentral built **Ask AI**, a feature that delivers state-specific guidance along with citations to the source material so you always know where the information came from.
 
 ---

--- a/data/blog/e-journal.md
+++ b/data/blog/e-journal.md
@@ -4,6 +4,8 @@ _Last updated September 06, 2025_
 
 [▶︎ Download the PDF version](/blog-pdf/ejournal.pdf)
 
+Tags: Rules & Regulations
+
 <!--STATE_PICKER-->
 
 ## Where can I get an e-Journal?

--- a/data/blog/journal-comparison.md
+++ b/data/blog/journal-comparison.md
@@ -1,5 +1,7 @@
 # NotaryCentral Electronic Journal (E-Journal) vs Jurat Inc. Electronic Journal (E-Journal) vs Paper Journal: A Practical Comparison
 
+Tags: Rules & Regulations
+
 The notary journal serves as the official record of your notarizations, protecting both you and the public. Traditionally, notaries used hardbound paper journals, but **electronic journal (e-journal)** solutions—like NotaryCentral’s Electronic Journal (E-Journal) and Jurat Inc.’s Electronic Journal (E-Journal)—offer modern advantages in compliance, accuracy, and efficiency.
 
 ---

--- a/data/blog/notary-business-software-ultimate-guide.md
+++ b/data/blog/notary-business-software-ultimate-guide.md
@@ -1,5 +1,7 @@
 # Notary Business Software – Ultimate Guide
 
+Tags: Rules & Regulations
+
 Running a mobile notary practice means juggling appointments, accounting, compliance, and client relationships at once. Modern notary business software bundles these everyday tasks into a single workspace so you can focus on signings instead of spreadsheets. Today’s leading platforms offer scheduling, mileage and expense tracking, accounting dashboards, and state-specific compliance guides in one place.
 
 This guide highlights the core modules every notary platform should provide and links out to detailed supporting posts for deeper dives.

--- a/data/blog/why-notarycentral-is-the-best-us-notary-app.md
+++ b/data/blog/why-notarycentral-is-the-best-us-notary-app.md
@@ -2,6 +2,8 @@
 
 [▶︎ Download the PDF version](/blog-pdf/why-notarycentral-is-the-best-app.pdf)
 
+Tags: Rules & Regulations
+
 ## What is NotaryCentral?
 **NotaryCentral is an all-in-one digital workspace created specifically for U.S. notaries**, helping streamline daily operations from any device. Developed with input from active notaries, it lets you schedule appointments, manage journal entries, track income, and stay compliant—without toggling between multiple apps. This centralization minimizes paperwork and simplifies recordkeeping.
 


### PR DESCRIPTION
## Summary
- allow blog posts to declare tags from markdown front-matter
- add client-side tag filtering with a dropdown on /blog
- tag rules & regulations related articles accordingly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run build` *(fails: fetch failed during prerendering)*

------
https://chatgpt.com/codex/tasks/task_e_68bf852f4ad88323be253b0b497f21a9