### PR TITLE
Add blog post on automatic quote calculations

### DIFF
--- a/app/automatic-quotes-online-scheduler/page.tsx
+++ b/app/automatic-quotes-online-scheduler/page.tsx
@@ -1,0 +1,45 @@
+import fs from "fs"
+import path from "path"
+import ReactMarkdown from "react-markdown"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Automatic Quotes in the Online Scheduler",
+  description:
+    "Set travel, document, and printing fees so NotaryCentral instantly displays accurate booking quotes.",
+}
+
+export default function AutomaticQuotesOnlineSchedulerPage() {
+  const markdownPath = path.join(
+    process.cwd(),
+    "data",
+    "blog",
+    "automatic-quotes-online-scheduler.md"
+  )
+  const markdown = fs.readFileSync(markdownPath, "utf8")
+  const lastUpdatedMatch = markdown.match(
+    /Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/
+  )
+  const isoDate = lastUpdatedMatch
+    ? new Date(lastUpdatedMatch[1]).toISOString()
+    : undefined
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: metadata.title,
+    description: metadata.description,
+    author: { "@type": "Person", name: "Alexander Leon" },
+    datePublished: isoDate,
+    dateModified: isoDate,
+  }
+
+  return (
+    <div className="prose lg:prose-lg dark:prose-invert mx-auto px-4 py-24 md:py-32 max-w-4xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ReactMarkdown>{markdown}</ReactMarkdown>
+    </div>
+  )
+}

--- a/data/blog/automatic-quotes-online-scheduler.md
+++ b/data/blog/automatic-quotes-online-scheduler.md
@@ -1,0 +1,35 @@
+# Automatic Quotes in the Online Scheduler
+**Last updated April 27, 2025**
+
+## Online Scheduling Needs Smart Pricing
+
+Offering online booking isn't just about showing your availability. A notary's fee can change based on travel distance, document type, and whether printing is required. Calculating each quote by hand slows you down and can lead to inconsistent pricing.
+
+## Manual Quotes Drain Time and Consistency
+
+- Every request needs its own math for mileage and document prep
+- Prices vary depending on who asked or how busy you are
+- Clients wait for answers instead of booking immediately
+
+## Let NotaryCentral Do the Math
+
+NotaryCentral's scheduler turns your pricing rules into instant quotes. You can set fees for:
+
+- Travel distance or mobile service
+- Document types and notarization complexity
+- Printing, scanbacks, or other add‑ons
+
+When a signer picks a service, the system combines these rules and shows a clear total before they confirm the appointment.
+
+## Controls Designed for Notary Owners
+
+- **Charge upfront at booking** to secure commitment and reduce no‑shows
+- Set your availability so clients only see times you want to offer
+- Offer mobile, online, or signer‑specified locations with unique fees
+- Add services like fingerprinting, set a fee, estimated duration, and buffer time between appointments
+
+## Consistent Quotes, Faster Bookings
+
+With smart pricing and automated calculations, every booking request gets a professional, consistent quote instantly. Clients know the full cost up front, and you save the time spent doing math and emailing back and forth.
+
+Activate automatic quotes in NotaryCentral's online scheduler and focus on the work that matters.


### PR DESCRIPTION
## Summary
- add "Automatic Quotes in the Online Scheduler" blog post covering smart pricing, travel fees, and payment controls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint must be installed)

------
https://chatgpt.com/codex/tasks/task_e_68c09e8adee08323b8dca48d34cd18fb