### PR TITLE
Add blog post on appointment reminders

### DIFF
--- a/app/never-miss-a-signing/page.tsx
+++ b/app/never-miss-a-signing/page.tsx
@@ -1,0 +1,44 @@
+import fs from "fs"
+import path from "path"
+import ReactMarkdown from "react-markdown"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Never Miss a Signing Again",
+  description:
+    "Automated reminders via email or push notifications keep notaries and signers on schedule, preventing no-shows that waste time and hurt revenue.",
+}
+
+export default function NeverMissASigningPage() {
+  const markdownPath = path.join(
+    process.cwd(),
+    "data/blog",
+    "never-miss-a-signing.md"
+  )
+  const markdown = fs.readFileSync(markdownPath, "utf8")
+  const lastUpdatedMatch = markdown.match(
+    /Last updated\s+([A-Za-z]+\s+\d{1,2},\s+\d{4})/
+  )
+  const isoDate = lastUpdatedMatch
+    ? new Date(lastUpdatedMatch[1]).toISOString()
+    : undefined
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: metadata.title,
+    description: metadata.description,
+    author: { "@type": "Person", name: "Alexander Leon" },
+    datePublished: isoDate,
+    dateModified: isoDate,
+  }
+
+  return (
+    <div className="prose lg:prose-lg dark:prose-invert mx-auto px-4 py-24 md:py-32 max-w-4xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ReactMarkdown>{markdown}</ReactMarkdown>
+    </div>
+  )
+}

--- a/data/blog/never-miss-a-signing.md
+++ b/data/blog/never-miss-a-signing.md
@@ -1,0 +1,12 @@
+# Never Miss a Signing Again
+_Last updated October 9, 2025_
+
+Busy days make it easy for both notaries and signers to overlook upcoming appointments. A signer who forgets to show can leave you waiting in the driveway and force a costly reschedule. Missed signings waste time, hurt your reputation, and cut into your revenue. NotaryCentral delivers smart reminders so everyone arrives on time.
+
+## Automated reminders for notaries and signers
+- Notaries receive reminder emails or push notifications before a signing
+- Signers get gentle reminder emails so they don't forget their appointment
+- Choose separate notification channels for yourself and your clients
+
+## Customize timing
+Set how far in advance reminders are sent. Need a nudge a day before, an hour before, or a follow-up after the signing? Configure reminders that fit your workflow so everyone stays on schedule.


### PR DESCRIPTION
## Summary
- add "Never Miss a Signing Again" blog post covering reminder emails and push notifications
- create Next.js page to render the new post with metadata and schema markup
- expand introduction to highlight the cost and frustration when signers also miss appointments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f5429d608323a690cee6b834f0cd